### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ readable.on('readable', () => {
 })
 ```
 
-^readabl.read is sync but the chunks are small
+^readable.read is sync but the chunks are small
 
 ---
 


### PR DESCRIPTION
Fixes a minor typo.

Maybe `readable` should be capitalized? See line 570...
